### PR TITLE
✨ Add transfer feature for emissions-generating goo

### DIFF
--- a/src/ArtGobblers.sol
+++ b/src/ArtGobblers.sol
@@ -241,6 +241,8 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
 
     event ArtGobbled(address indexed user, uint256 indexed gobblerId, address indexed nft, uint256 id);
 
+    event GooTransfer(address indexed from, address indexed to, uint256 gooAmount);
+
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -784,6 +786,20 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
 
         // Mint the corresponding amount of ERC20 goo.
         goo.mintForGobblers(msg.sender, gooAmount);
+    }
+
+    /// @notice Transfer goo directly from your emission balance,
+    /// to a recipient's emission balance.
+    /// @param to The recipient's address.
+    /// @param gooAmount The amount of goo to transfer.
+    function transferGoo(address to, uint256 gooAmount) external {
+        // Decrease msg.sender's virtual goo balance.
+        updateUserGooBalance(msg.sender, gooAmount, GooBalanceUpdateType.DECREASE);
+
+        // Increase recipient's virtual goo balance.
+        updateUserGooBalance(to, gooAmount, GooBalanceUpdateType.INCREASE);
+
+        emit GooTransfer(msg.sender, to, gooAmount);
     }
 
     /// @notice Burn an amount of a user's virtual goo balance. Only callable

--- a/src/ArtGobblers.sol
+++ b/src/ArtGobblers.sol
@@ -223,6 +223,12 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
     mapping(uint256 => mapping(address => mapping(uint256 => uint256))) public getCopiesOfArtGobbledByGobbler;
 
     /*//////////////////////////////////////////////////////////////
+                            GOO TRANSFER STATE
+    //////////////////////////////////////////////////////////////*/
+
+    mapping(address => mapping(address => uint256)) public gooAllowance;
+
+    /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
@@ -788,18 +794,74 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
         goo.mintForGobblers(msg.sender, gooAmount);
     }
 
+    /// @notice Approve a spender account to transfer internal goo on user's behalf.
+    /// @param spender The spender account being approved.
+    /// @param amount The amount of goo to approve spender for.
+    function approveGoo(address spender, uint256 amount) public virtual returns (bool) {
+        gooAllowance[msg.sender][spender] = amount;
+
+        emit Approval(msg.sender, spender, amount);
+
+        return true;
+    }
+
     /// @notice Transfer goo directly from your emission balance,
     /// to a recipient's emission balance.
-    /// @param to The recipient's address.
+    /// @param to The goo recipient's address.
     /// @param gooAmount The amount of goo to transfer.
-    function transferGoo(address to, uint256 gooAmount) external {
-        // Decrease msg.sender's virtual goo balance.
-        updateUserGooBalance(msg.sender, gooAmount, GooBalanceUpdateType.DECREASE);
+    function transferGoo(address to, uint256 gooAmount) external returns (bool) {
+        // Will revert due to underflow if we're decreasing by more than the user's current balance.
+        uint256 fromUpdatedBalance = gooBalance(msg.sender) - gooAmount;
+        getUserData[msg.sender].lastBalance = uint128(fromUpdatedBalance);
+        // Don't need to do checked addition in the increase case.
+        uint256 toUpdatedBalance;
+        unchecked {
+            toUpdatedBalance = gooBalance(to) + gooAmount;
+            getUserData[to].lastBalance = uint128(toUpdatedBalance);
+        }
 
-        // Increase recipient's virtual goo balance.
-        updateUserGooBalance(to, gooAmount, GooBalanceUpdateType.INCREASE);
+        // Update both accounts lastTimestamp now
+        getUserData[msg.sender].lastTimestamp = uint64(block.timestamp);
+        getUserData[to].lastTimestamp = uint64(block.timestamp);
 
+        emit GooBalanceUpdated(msg.sender, fromUpdatedBalance);
+        emit GooBalanceUpdated(to, toUpdatedBalance);
         emit GooTransfer(msg.sender, to, gooAmount);
+    }
+
+    /// @notice Transfer goo directly from a user's emission balance,
+    /// to a recipient's emission balance.
+    /// @param from The goo sender's address.
+    /// @param to The goo recipient's address.
+    /// @param gooAmount The amount of goo to transfer.
+    function transferGooFrom(
+        address from,
+        address to,
+        uint256 gooAmount
+    ) external returns (bool) {
+        uint256 allowed = gooAllowance[from][msg.sender]; // Saves gas for limited approvals.
+
+        if (allowed != type(uint256).max) gooAllowance[from][msg.sender] = allowed - gooAmount;
+
+        // Will revert due to underflow if we're decreasing by more than the user's current balance.
+        uint256 fromUpdatedBalance = gooBalance(from) - gooAmount;
+        getUserData[from].lastBalance = uint128(fromUpdatedBalance);
+        // Don't need to do checked addition in the increase case.
+        uint256 toUpdatedBalance;
+        unchecked {
+            toUpdatedBalance = gooBalance(to) + gooAmount;
+            getUserData[to].lastBalance = uint128(toUpdatedBalance);
+        }
+
+        // Update both accounts lastTimestamp now
+        getUserData[from].lastTimestamp = uint64(block.timestamp);
+        getUserData[to].lastTimestamp = uint64(block.timestamp);
+
+        emit GooBalanceUpdated(from, fromUpdatedBalance);
+        emit GooBalanceUpdated(to, toUpdatedBalance);
+        emit GooTransfer(from, to, gooAmount);
+
+        return true;
     }
 
     /// @notice Burn an amount of a user's virtual goo balance. Only callable

--- a/src/ArtGobblers.sol
+++ b/src/ArtGobblers.sol
@@ -813,20 +813,21 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
         // Will revert due to underflow if we're decreasing by more than the user's current balance.
         uint256 fromUpdatedBalance = gooBalance(msg.sender) - gooAmount;
         getUserData[msg.sender].lastBalance = uint128(fromUpdatedBalance);
+        getUserData[msg.sender].lastTimestamp = uint64(block.timestamp);
+
         // Don't need to do checked addition in the increase case.
         uint256 toUpdatedBalance;
         unchecked {
             toUpdatedBalance = gooBalance(to) + gooAmount;
             getUserData[to].lastBalance = uint128(toUpdatedBalance);
+            getUserData[to].lastTimestamp = uint64(block.timestamp);
         }
-
-        // Update both accounts lastTimestamp now
-        getUserData[msg.sender].lastTimestamp = uint64(block.timestamp);
-        getUserData[to].lastTimestamp = uint64(block.timestamp);
 
         emit GooBalanceUpdated(msg.sender, fromUpdatedBalance);
         emit GooBalanceUpdated(to, toUpdatedBalance);
         emit GooTransfer(msg.sender, to, gooAmount);
+
+        return true;
     }
 
     /// @notice Transfer goo directly from a user's emission balance,
@@ -839,23 +840,21 @@ contract ArtGobblers is GobblersERC721, LogisticVRGDA, Owned, ERC1155TokenReceiv
         address to,
         uint256 gooAmount
     ) external returns (bool) {
-        uint256 allowed = gooAllowance[from][msg.sender]; // Saves gas for limited approvals.
-
+        uint256 allowed = (from == msg.sender) ? type(uint256).max : gooAllowance[from][msg.sender];
         if (allowed != type(uint256).max) gooAllowance[from][msg.sender] = allowed - gooAmount;
 
         // Will revert due to underflow if we're decreasing by more than the user's current balance.
         uint256 fromUpdatedBalance = gooBalance(from) - gooAmount;
         getUserData[from].lastBalance = uint128(fromUpdatedBalance);
+        getUserData[from].lastTimestamp = uint64(block.timestamp);
+
         // Don't need to do checked addition in the increase case.
         uint256 toUpdatedBalance;
         unchecked {
             toUpdatedBalance = gooBalance(to) + gooAmount;
             getUserData[to].lastBalance = uint128(toUpdatedBalance);
+            getUserData[to].lastTimestamp = uint64(block.timestamp);
         }
-
-        // Update both accounts lastTimestamp now
-        getUserData[from].lastTimestamp = uint64(block.timestamp);
-        getUserData[to].lastTimestamp = uint64(block.timestamp);
 
         emit GooBalanceUpdated(from, fromUpdatedBalance);
         emit GooBalanceUpdated(to, toUpdatedBalance);

--- a/test/ArtGobblers.t.sol
+++ b/test/ArtGobblers.t.sol
@@ -945,6 +945,30 @@ contract ArtGobblersTest is DSTestPlus {
         assertEq(gobblers.gooAllowance(users[0], users[2]), transferAmount);
     }
 
+    function testGooSelfTransfer() public {
+        mintGobblerToAddress(users[0], 1);
+        vm.warp(block.timestamp + 1 days);
+        setRandomnessAndReveal(1, "seed");
+        vm.warp(block.timestamp + 100000);
+        uint256 initialBalance = gobblers.gooBalance(users[0]);
+        uint256 transferAmount = initialBalance / 10; //10%
+        vm.prank(users[0]);
+        gobblers.transferGoo(users[0], transferAmount);
+        assertEq(gobblers.gooBalance(users[0]), initialBalance);
+    }
+
+    function testGooSelfTransferFrom() public {
+        mintGobblerToAddress(users[0], 1);
+        vm.warp(block.timestamp + 1 days);
+        setRandomnessAndReveal(1, "seed");
+        vm.warp(block.timestamp + 100000);
+        uint256 initialBalance = gobblers.gooBalance(users[0]);
+        uint256 transferAmount = initialBalance / 10; //10%
+        vm.prank(users[0]);
+        gobblers.transferGooFrom(users[0], users[0], transferAmount);
+        assertEq(gobblers.gooBalance(users[0]), initialBalance);
+    }
+
     /// @notice Test that we can't add goo when we don't have the corresponding ERC20 balance.
     function testCantAddMoreGooThanOwned() public {
         mintGobblerToAddress(users[0], 1);

--- a/test/ArtGobblers.t.sol
+++ b/test/ArtGobblers.t.sol
@@ -835,6 +835,27 @@ contract ArtGobblersTest is DSTestPlus {
         assertEq(gobblers.gooBalance(users[0]), additionAmount);
     }
 
+    /// @notice Test that a goo approval reflects in gooAllowance.
+    function testGooApproval() public{}
+
+    /// @notice Test that a goo allowance can be revoked by setting it back to zero.
+    function testGooRevokeApproval() public {}
+
+    /// @notice Test that an internal goo transfer works under ideal conditions.
+    function testGooTransfer() public{}
+
+    /// @notice Test that an internal goo transfer reverts if attempting
+    /// to transfer more goo than sender owns.
+    function testCantTransferMoreGooThanOwned() public{}
+
+    /// @notice Test that an account can internally transfer goo on behalf of
+    /// another account given an adequate allowance.
+    function testGooTransferFrom() public{}
+
+    /// @notice Test that an account cannot internally transfer goo on behalf of
+    /// another account without adequate allowance.
+    function testCantTransferFromMoreGooThanApproved public{}
+
     /// @notice Test that we can't add goo when we don't have the corresponding ERC20 balance.
     function testCantAddMoreGooThanOwned() public {
         mintGobblerToAddress(users[0], 1);

--- a/test/ArtGobblers.t.sol
+++ b/test/ArtGobblers.t.sol
@@ -836,25 +836,38 @@ contract ArtGobblersTest is DSTestPlus {
     }
 
     /// @notice Test that a goo approval reflects in gooAllowance.
-    function testGooApproval() public{}
+    function testGooApproval() public {
+        uint256 allowance = 1234569420;
+        vm.prank(users[0]);
+        gobblers.approveGoo(users[1], allowance);
+        assertEq(gobblers.gooAllowance(users[0], users[1]), allowance);
+    }
 
     /// @notice Test that a goo allowance can be revoked by setting it back to zero.
-    function testGooRevokeApproval() public {}
+    function testGooRevokeApproval() public {
+        uint256 allowance = 1234569420;
+        vm.prank(users[0]);
+        gobblers.approveGoo(users[1], allowance);
+        assertEq(gobblers.gooAllowance(users[0], users[1]), allowance);
+        vm.prank(users[0]);
+        gobblers.approveGoo(users[1], 0);
+        assertEq(gobblers.gooAllowance(users[0], users[1]), 0);
+    }
 
     /// @notice Test that an internal goo transfer works under ideal conditions.
-    function testGooTransfer() public{}
+    function testGooTransfer() public {}
 
     /// @notice Test that an internal goo transfer reverts if attempting
     /// to transfer more goo than sender owns.
-    function testCantTransferMoreGooThanOwned() public{}
+    function testCantTransferMoreGooThanOwned() public {}
 
     /// @notice Test that an account can internally transfer goo on behalf of
     /// another account given an adequate allowance.
-    function testGooTransferFrom() public{}
+    function testGooTransferFrom() public {}
 
     /// @notice Test that an account cannot internally transfer goo on behalf of
     /// another account without adequate allowance.
-    function testCantTransferFromMoreGooThanApproved public{}
+    function testCantTransferFromMoreGooThanApproved() public {}
 
     /// @notice Test that we can't add goo when we don't have the corresponding ERC20 balance.
     function testCantAddMoreGooThanOwned() public {


### PR DESCRIPTION
Gm sers.

Any opinions on adding a `transferGoo` function to the ArtGobblers contract, such as the one I've implemented here?

I think this would help composability by allowing users to transfer GOO to each other without going through the gas-costly process of withdrawing to ERC20 and then re-depositing each time.

I'll add a few tests for it as well if peeps are in favor 🫡